### PR TITLE
Changed .primaryColor to match Figma's design

### DIFF
--- a/EN/Resources/Colors.xcassets/PrimaryColor.colorset/Contents.json
+++ b/EN/Resources/Colors.xcassets/PrimaryColor.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFF",
-          "green" : "0x47",
-          "red" : "0x00"
+          "blue" : "0x9B",
+          "green" : "0x52",
+          "red" : "0x1F"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
I'm going to see this as a little test as well and therefore made this extremely small PR.
I noticed the color .primaryColor is not matching the button/primaryColor on Figma.