### PR TITLE
Add custom transition animations for onboarding screens

### DIFF
--- a/EN.xcodeproj/project.pbxproj
+++ b/EN.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		74D95DE72487E7E500836229 /* NSLocalizedString+Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D95DCC248660C700836229 /* NSLocalizedString+Localized.swift */; };
 		74D95DE82487E90D00836229 /* OnboardingStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D95DC624865B9900836229 /* OnboardingStep.swift */; };
 		74D95DE92487E9DA00836229 /* UIColor+Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D95DBE2486519B00836229 /* UIColor+Theme.swift */; };
+		DA99C57F248A8E2B0019BCFE /* NavigationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA99C57E248A8E2B0019BCFE /* NavigationManager.swift */; };
+		DA99C581248A8E990019BCFE /* OnboardingStepViewAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA99C580248A8E990019BCFE /* OnboardingStepViewAnimator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -63,6 +65,8 @@
 		74D95DDB2487C56100836229 /* ENUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ENUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		74D95DDD2487C56100836229 /* ENUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ENUnitTests.swift; sourceTree = "<group>"; };
 		74D95DDF2487C56100836229 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DA99C57E248A8E2B0019BCFE /* NavigationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationManager.swift; sourceTree = "<group>"; };
+		DA99C580248A8E990019BCFE /* OnboardingStepViewAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingStepViewAnimator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -177,6 +181,8 @@
 			isa = PBXGroup;
 			children = (
 				74D95DC424865AB000836229 /* Haptic.swift */,
+				DA99C57E248A8E2B0019BCFE /* NavigationManager.swift */,
+				DA99C580248A8E990019BCFE /* OnboardingStepViewAnimator.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -295,9 +301,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA99C57F248A8E2B0019BCFE /* NavigationManager.swift in Sources */,
 				74D95DC524865AB000836229 /* Haptic.swift in Sources */,
 				74D95DC324865A0E00836229 /* Button.swift in Sources */,
 				74D95DBF2486519B00836229 /* UIColor+Theme.swift in Sources */,
+				DA99C581248A8E990019BCFE /* OnboardingStepViewAnimator.swift in Sources */,
 				74D95DC924865DCC00836229 /* UIViewController+UINavigationController.swift in Sources */,
 				74D95D9D248638C100836229 /* AppDelegate.swift in Sources */,
 				74D95DD624866B9900836229 /* OnboardingManager.swift in Sources */,

--- a/EN/Controllers/NavigationController.swift
+++ b/EN/Controllers/NavigationController.swift
@@ -9,9 +9,13 @@ import UIKit
 
 class NavigationController: UINavigationController {
 
+    private var manager: NavigationManager! = nil
+
     override func viewDidLoad() {
         super.viewDidLoad()
         
         self.view.backgroundColor = .navigationControllerBackgroundColor            
+
+        manager = NavigationManager(controller: self)
     }
 }

--- a/EN/Controllers/OnboardingStepViewController.swift
+++ b/EN/Controllers/OnboardingStepViewController.swift
@@ -9,6 +9,12 @@ import UIKit
 
 class OnboardingStepViewController: UIViewController {
 
+    lazy public var progressView: UIProgressView = {
+        let progressView = UIProgressView()
+        progressView.translatesAutoresizingMaskIntoConstraints = false
+        return progressView
+    }()
+
     lazy private var imageView: UIImageView = {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
@@ -31,10 +37,16 @@ class OnboardingStepViewController: UIViewController {
         return button
     }()
 
-    lazy private var viewsInDisplayOrder = [imageView, button, label]
+    lazy public var viewsAnimatedTransition = [imageView, label]
+
+    lazy private var viewsInDisplayOrder = [progressView, imageView, button, label]
 
     var index: Int
     var onboardingStep: OnboardingStep
+
+    var progress: Float {
+        return max(0.01, Float(index) / Float(OnboardingManager.shared.onboardingSteps.count - 1))
+    }
 
     // MARK: - Lifecycle
 
@@ -48,6 +60,7 @@ class OnboardingStepViewController: UIViewController {
 
         super.init(nibName: nil, bundle: nil)
 
+        self.progressView.progress = self.progress
         self.button.title = self.onboardingStep.buttonTitle
         self.imageView.image = self.onboardingStep.image
         self.label.attributedText = self.onboardingStep.attributedText
@@ -82,7 +95,13 @@ class OnboardingStepViewController: UIViewController {
         var constraints = [[NSLayoutConstraint]()]
 
         constraints.append([
-            imageView.topAnchor.constraint(equalTo: view.topAnchor, constant: 0),
+            progressView.topAnchor.constraint(equalTo: view.topAnchor, constant: 0),
+            progressView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.3, constant: 1),
+            progressView.centerXAnchor.constraint(equalTo: view.centerXAnchor, constant: 0)
+        ])
+
+        constraints.append([
+            imageView.topAnchor.constraint(equalTo: progressView.bottomAnchor, constant: 0),
             imageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             imageView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor, multiplier: 0.83, constant: 1)

--- a/EN/Utilities/NavigationManager.swift
+++ b/EN/Utilities/NavigationManager.swift
@@ -1,0 +1,114 @@
+/*
+* Copyright (c) 2020 De Staat der Nederlanden, Ministerie van Volksgezondheid, Welzijn en Sport.
+*  Licensed under the EUROPEAN UNION PUBLIC LICENCE v. 1.2
+*
+*  SPDX-License-Identifier: EUPL-1.2
+*/
+
+import UIKit
+
+///
+/// Class that enables custom animations in the UINavigationManager
+/// Facilitates the animations used in the Onboarding screens
+///
+class NavigationManager: NSObject, UINavigationControllerDelegate, UIGestureRecognizerDelegate {
+
+    private var interactionController: UIPercentDrivenInteractiveTransition?
+
+    /// Gesture recognizer used for custom back-navigation swipes from the left edge of the screen
+    private let edgeGestureRecognizer = UIScreenEdgePanGestureRecognizer()
+
+    private weak var navigationController: NavigationController?
+
+    init(controller: NavigationController) {
+        super.init()
+
+        self.navigationController = controller
+        self.edgeGestureRecognizer.addTarget(self, action: #selector(handleSwipeFromLeftEdge))
+        edgeGestureRecognizer.edges = .left
+        edgeGestureRecognizer.delegate = self
+        controller.view.addGestureRecognizer(edgeGestureRecognizer)
+
+        controller.delegate = self
+        controller.interactivePopGestureRecognizer?.delegate = self
+
+    }
+
+    func navigationController(_ navigationController: UINavigationController,
+                              animationControllerFor operation: UINavigationController.Operation,
+                              from fromVC: UIViewController,
+                              to toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        if let fromVC = fromVC as? OnboardingStepViewController,
+              let toVC = toVC as? OnboardingStepViewController {
+            switch operation {
+            case .push:
+                return OnboardingStepViewAnimator(fromVC: fromVC, toVC: toVC, push: true)
+            case .pop:
+                return OnboardingStepViewAnimator(fromVC: fromVC, toVC: toVC, push: false)
+            default:
+                break
+            }
+        }
+        return nil
+    }
+
+    func navigationController(_ navigationController: UINavigationController,
+                              interactionControllerFor animationController: UIViewControllerAnimatedTransitioning
+    ) -> UIViewControllerInteractiveTransitioning? {
+        return interactionController
+    }
+
+    ///
+    /// This callback enables the use of the original interactivePopGestureRecognizer
+    /// and our own custom edgeGestureRecognizer
+    /// This allows the use of both normal and custom back navigation animations in the UINavigationViewController
+    ///
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+
+        guard let navigationController = navigationController,
+            navigationController.viewControllers.count >= 2 else {
+                return false
+        }
+        let fromVC = navigationController.viewControllers.last
+        let toVC = navigationController.viewControllers[navigationController.viewControllers.count - 2]
+
+        if fromVC is OnboardingStepViewController && toVC is OnboardingStepViewController {
+            if gestureRecognizer == edgeGestureRecognizer {
+                return true
+            }
+        } else if gestureRecognizer == navigationController.interactivePopGestureRecognizer {
+            return true
+        }
+        return false
+    }
+
+    @objc func handleSwipeFromLeftEdge(gestureRecognizer: UIScreenEdgePanGestureRecognizer) {
+        guard let gestureView = gestureRecognizer.view else {
+            return
+        }
+
+        let translate = gestureRecognizer.translation(in: gestureRecognizer.view)
+        let percent = translate.x / gestureView.bounds.size.width
+
+        switch gestureRecognizer.state {
+        case .began:
+            self.interactionController = UIPercentDrivenInteractiveTransition()
+            navigationController?.popViewController(animated: true)
+
+        case .changed:
+            self.interactionController?.update(percent)
+
+        case .ended:
+            let velocity = gestureRecognizer.velocity(in: gestureRecognizer.view)
+            if percent > 0.5 || velocity.x > 0 {
+                self.interactionController?.finish()
+            } else {
+                self.interactionController?.cancel()
+            }
+            self.interactionController = nil
+
+        default:
+            break
+        }
+    }
+}

--- a/EN/Utilities/OnboardingStepViewAnimator.swift
+++ b/EN/Utilities/OnboardingStepViewAnimator.swift
@@ -1,0 +1,65 @@
+/*
+* Copyright (c) 2020 De Staat der Nederlanden, Ministerie van Volksgezondheid, Welzijn en Sport.
+*  Licensed under the EUROPEAN UNION PUBLIC LICENCE v. 1.2
+*
+*  SPDX-License-Identifier: EUPL-1.2
+*/
+
+import UIKit
+
+class OnboardingStepViewAnimator: NSObject, UIViewControllerAnimatedTransitioning {
+
+    private let fromVC: OnboardingStepViewController
+    private let toVC: OnboardingStepViewController
+    private let push: Bool
+
+    init(fromVC: OnboardingStepViewController, toVC: OnboardingStepViewController, push: Bool) {
+        self.fromVC = fromVC
+        self.toVC = toVC
+        self.push = push
+    }
+
+    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+        return 0.3
+    }
+
+    func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+        // Fade-in new VC
+        toVC.view.alpha = 0.0
+
+        // Progress bar animation
+        toVC.progressView.progress = fromVC.progress
+        toVC.progressView.layoutIfNeeded()
+
+        fromVC.progressView.progress = toVC.progress
+        toVC.progressView.progress = toVC.progress
+
+        // Set up sliding animation
+        let toX: CGFloat = push ? 170 : -170
+        let fromX: CGFloat = push ? -170 : 170
+
+        fromVC.viewsAnimatedTransition.forEach { $0.transform = CGAffineTransform(translationX: 0, y: 0) }
+        toVC.viewsAnimatedTransition.forEach { $0.transform = CGAffineTransform(translationX: toX, y: 0) }
+
+        transitionContext.containerView.addSubview(toVC.view)
+
+        UIView.animate(withDuration: self.transitionDuration(using: transitionContext),
+                       animations: {
+                        self.toVC.view.alpha = 1.0
+
+                        self.fromVC.progressView.layoutIfNeeded()
+                        self.toVC.progressView.layoutIfNeeded()
+
+                        self.fromVC.viewsAnimatedTransition.forEach {
+                            $0.transform = CGAffineTransform(translationX: fromX, y: 0)
+                        }
+                        self.toVC.viewsAnimatedTransition.forEach {
+                            $0.transform = CGAffineTransform(translationX: 0, y: 0)
+                        }
+        },
+                       completion: { _ in
+                        self.fromVC.progressView.progress = self.fromVC.progress
+                        transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
+        })
+    }
+}


### PR DESCRIPTION
These changes implement a custom transition on the onboarding screens that are less jarring than the current replace-the-entire-viewcontroller transition.

The button stays fixed and a new progressbar has been added to the top that animates along with the transition.

The underlying viewcontroller and navigationcontroller structure remains the same with these changes.

![onboarding](https://user-images.githubusercontent.com/2012474/83897373-0e235500-a745-11ea-82b0-02e24b476908.gif)

