### PR TITLE
Travis-CI patch (continuous integration testing & reproducible builds)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,48 @@
+<<<<<<< HEAD
+---
+before_script:
+  - chmod +x ./tools/scripts/ci/add-key.sh
+  - chmod +x ./tools/scripts/ci/cibuild
+  - chmod +x ./tools/scripts/ci/citest
+  - chmod +x ./tools/scripts/ci/remove-key.sh
+  - gem install cocoapods -v '0.32.1'
+
+# branch whitelist
+branches:
+  only:
+    - master     # test the master branch
+    - /patch-(.*)/  # test every branch which starts with "patch-"
+
+language: objective-c
+os: osx
+osx_image: xcode11  # Xcode 11.0	macOS 10.14.6
+xcode_project: EN.xcodeproj  # path to your xcodeproj folder
+xcode_scheme: ENCoreTests
+xcode_destination: platform=iOS Simulator,OS=10.14.6,name=iPhone X
+env:
+  global:
+    - |
+      - APP_NAME="CoronaMelder"
+      - 'DEVELOPER_NAME="nl.rijksoverheid.en"'
+      - PROFILE_NAME="Distribution"
+      - SWIFT_VERSION=5.2
+
+# pod install
+install:
+  - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
+
+script:
+  - ./tools/scripts/ci/add-key.sh
+  - ./tools/scripts/ci/cibuild
+  - ./tools/scripts/ci/citest
+  - ./tools/scripts/ci/remove-key.sh
+
+addons:
+  homebrew
+
+# Optional: disable email notifications about the outcome of your builds
+notifications:
+  email: false
+=======
+language: objective-c
+>>>>>>> 8d41718... patch-travis-ci initial commit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 ---
 before_script:
   - chmod +x ./tools/scripts/ci/add-key.sh
@@ -43,6 +42,3 @@ addons:
 # Optional: disable email notifications about the outcome of your builds
 notifications:
   email: false
-=======
-language: objective-c
->>>>>>> 8d41718... patch-travis-ci initial commit

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ This increases the chance that we might be able to use your contribution (or it 
 
 Run `make dev` && `make project` to get started. Homebrew (https://brew.sh) is a requirement to install dependencies.
 
+## Continuous Integration & reproducible builds
+
+In order to facilitate CI and reproducible builds (https://github.com/minvws/nl-covid19-notification-app-coordination/issues/6) this codebase can be build using Travis CI (see .travis.yml file).
+
 ## Disclaimer
 
 Keep in mind that the Apple Exposure Notification API is only accessible by verified health authorities. Other devices trying to access the API using the code in this repository will fail to do so.

--- a/tools/scripts/ci/add-key.sh
+++ b/tools/scripts/ci/add-key.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+echo "*********************"
+echo "*     add key       *"
+echo "*********************"
+
+# Create a custom keychain
+# security create-keychain -p travis ios-build.keychain
+
+# Make the custom keychain default, so xcodebuild will use it for signing
+# security default-keychain -s ios-build.keychain
+
+# Unlock the keychain
+# security unlock-keychain -p travis ios-build.keychain
+
+# Set keychain timeout to 1 hour for long builds
+# see http://www.egeek.me/2013/02/23/jenkins-and-xcode-user-interaction-is-not-allowed/
+# security set-keychain-settings -t 3600 -l ~/Library/Keychains/ios-build.keychain
+
+# Add certificates to keychain and allow codesign to access them
+# security import ./scripts/certs/apple.cer -k ~/Library/Keychains/ios-build.keychain -T /usr/bin/codesign
+# security import ./scripts/certs/dist.cer -k ~/Library/Keychains/ios-build.keychain -T /usr/bin/codesign
+# security import ./scripts/certs/dist.p12 -k ~/Library/Keychains/ios-build.keychain -P $KEY_PASSWORD -T /usr/bin/codesign
+
+
+# Put the provisioning profile in place
+# mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+# cp "./scripts/profile/$PROFILE_NAME.mobileprovision" ~/Library/MobileDevice/Provisioning\ Profiles/
+
+exit 0

--- a/tools/scripts/ci/cibuild
+++ b/tools/scripts/ci/cibuild
@@ -1,0 +1,13 @@
+#!/bin/sh
+if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+  echo "This is a pull request. No deployment will be done."
+  exit 0
+fi
+echo "*********************"
+echo "*     Make dev      *"
+echo "*********************"
+make dev
+echo "*********************"
+echo "*     Make project  *"
+echo "*********************"
+make project

--- a/tools/scripts/ci/citest
+++ b/tools/scripts/ci/citest
@@ -6,4 +6,5 @@ fi
 echo "*********************"
 echo "*      CI tests     *"
 echo "*********************"
-make dev
+
+exit 0

--- a/tools/scripts/ci/citest
+++ b/tools/scripts/ci/citest
@@ -1,0 +1,9 @@
+#!/bin/sh
+if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
+  echo "This is a pull request. No deployment will be done."
+  exit 0
+fi
+echo "*********************"
+echo "*      CI tests     *"
+echo "*********************"
+make dev

--- a/tools/scripts/ci/remove-key.sh
+++ b/tools/scripts/ci/remove-key.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+echo "*********************"
+echo "*     remove key    *"
+echo "*********************"
+
+# security delete-keychain ios-build.keychain
+# rm -f "~/Library/MobileDevice/Provisioning Profiles/$PROFILE_NAME.mobileprovision"
+
+exit 0


### PR DESCRIPTION
In order to facilitate continuous integration testing and reproducible builds (https://github.com/minvws/nl-covid19-notification-app-coordination/issues/6) this patch allows the codebase to be build using Travis CI (see `.travis.yml` file).

Currently configured with the following targets:

- Mac OS X 10.14.6
- x86_64-apple-darwin18.7.0
- iPhoneOS13.0.sdk - iOS 13.0 (iphoneos13.0)
- iPhoneSimulator13.0.sdk - Simulator - iOS 13.0 (iPhone X)
- Swift version 5.2
- homebrew
- cocoapods version 0.32.1

See also related issue on reproducable builds: https://github.com/minvws/nl-covid19-notification-app-coordination/issues/6


Sample output from a successful travis build run attached.

-------------------------------------------------------------
[log.txt](https://github.com/minvws/nl-covid19-notification-app-ios/files/4912532/log.txt)

