### PR TITLE
Fix issue that makes share sheet close button unresponsive

### DIFF
--- a/Sources/ENCore/App/Features/Main/MainViewController.swift
+++ b/Sources/ENCore/App/Features/Main/MainViewController.swift
@@ -185,11 +185,11 @@ final class MainViewController: ViewController, MainViewControllable, StatusList
         router?.detachSharing(shouldHideViewController: shouldHideViewController)
     }
 
-    func displayShareSheet(usingViewController viewcontroller: ViewController, completion: @escaping (() -> ())) {
+    func displayShareSheet(usingViewController viewcontroller: ViewController, completion: @escaping ((Bool) -> ())) {
         if let storeLink = URL(string: .shareAppUrl) {
             let activityVC = UIActivityViewController(activityItems: [.shareAppTitle as String, storeLink], applicationActivities: nil)
-            activityVC.completionWithItemsHandler = { _, _, _, _ in
-                completion()
+            activityVC.completionWithItemsHandler = { _, completed, _, _ in
+                completion(completed)
             }
             viewcontroller.present(activityVC, animated: true)
         } else {

--- a/Sources/ENCore/App/Features/Main/MoreInformation/Sharing/ShareSheetBuilder.swift
+++ b/Sources/ENCore/App/Features/Main/MoreInformation/Sharing/ShareSheetBuilder.swift
@@ -11,7 +11,7 @@ import Foundation
 /// @mockable
 protocol ShareSheetListener: AnyObject {
     func shareSheetDidComplete(shouldHideViewController: Bool)
-    func displayShareSheet(usingViewController viewcontroller: ViewController, completion: @escaping (() -> ()))
+    func displayShareSheet(usingViewController viewcontroller: ViewController, completion: @escaping ((Bool) -> ()))
 }
 
 protocol ShareSheetDependency {

--- a/Sources/ENCore/App/Features/Main/MoreInformation/Sharing/ShareSheetViewController.swift
+++ b/Sources/ENCore/App/Features/Main/MoreInformation/Sharing/ShareSheetViewController.swift
@@ -33,8 +33,10 @@ final class ShareSheetViewController: ViewController, ShareSheetViewControllable
 
         internalView.button.action = { [weak self] in
             if let viewController = self {
-                self?.listener?.displayShareSheet(usingViewController: viewController, completion: {
-                    self?.didTapClose()
+                self?.listener?.displayShareSheet(usingViewController: viewController, completion: { completed in
+                    if completed {
+                        self?.didTapClose()
+                    }
                 })
             } else {
                 self?.logError("Couldn't retreive a viewcontroller")


### PR DESCRIPTION
## The issue
The close button of ShareSheetViewController would become unresponsive after the user cancelled the
share extension of a specific activity. See video.

![Untitled](https://user-images.githubusercontent.com/134170/90392274-d747b480-e08e-11ea-803c-ddd79d0b82a8.gif)

## My solution
I now only close the ShareSheetViewController if the user completed sharing. When the user cancels the sharing, we don't ask our listener to close us and thereby won't trigger the root cause (see below). Note that this introduces a change in behavior, as a tap outside the system share sheet no longer closes ShareSheetViewController as well. I think that's fine or maybe even an improvement.

## Root cause
When the share extension is closed, the UIActivityViewController itself is not closed and is still presented. This causes https://github.com/minvws/nl-covid19-notification-app-ios/blob/master/Sources/ENCore/App/Features/Main/MainViewController.swift#L119 not to actually dismiss the ShareSheetViewController. This method is called by MainRouter here: https://github.com/minvws/nl-covid19-notification-app-ios/blob/master/Sources/ENCore/App/Features/Main/MainRouter.swift#L110. Since it can't know if the dismissal worked, it assumes it did so and breaks ties with  ShareSheetViewController (i.e. it sets `self.shareViewController = nil`). The next time the close button is tapped, `self.shareViewController` is `nil` so it can't pass it to `dismiss`. This could probably be improved to fix other potential issues.