### PR TITLE
Add missing period in the "Coronatest aanvragen" screen.

### DIFF
--- a/Sources/ENCore/Resources/nl.lproj/Localizable.strings
+++ b/Sources/ENCore/Resources/nl.lproj/Localizable.strings
@@ -286,7 +286,7 @@
 "moreInformation.cell.infected.title" = "GGD-sleutel doorgeven";
 "moreInformation.cell.infected.subtitle" = "Ga hierheen als de GGD je belt met de uitslag van je coronatest";
 
-"moreInformation.info.title" = "Houd je burgerservicenummer bij de hand. Dit vind je op je paspoort of identiteitskaart";
+"moreInformation.info.title" = "Houd je burgerservicenummer bij de hand. Dit vind je op je paspoort of identiteitskaart.";
 
 "moreInformation.complaints.item1" = "verkoudheidsklachten zoals neusverkoudheid, loopneus, niezen, keelpijn";
 "moreInformation.complaints.item2" = "hoesten";

--- a/Sources/ENCore/Resources/pl.lproj/Localizable.strings
+++ b/Sources/ENCore/Resources/pl.lproj/Localizable.strings
@@ -285,7 +285,7 @@
 "moreInformation.cell.infected.title" = "Przekaż klucz GGD";
 "moreInformation.cell.infected.subtitle" = "Przejdź tutaj, gdy GGD zadzwoni do Ciebie z wynikami testu na obecność koronawirusa";
 
-"moreInformation.info.title" = "Miej pod ręką swój numer obsługi mieszkańca (BSN). Znajdziesz go w paszporcie lub na dowodzie osobistym";
+"moreInformation.info.title" = "Miej pod ręką swój numer obsługi mieszkańca (BSN). Znajdziesz go w paszporcie lub na dowodzie osobistym.";
 
 "moreInformation.complaints.item1" = "objawy przeziębienia takie jak nieżyt nosa, katar, kichanie, ból gardła";
 "moreInformation.complaints.item2" = "kaszel";

--- a/Sources/ENCore/Resources/tr.lproj/Localizable.strings
+++ b/Sources/ENCore/Resources/tr.lproj/Localizable.strings
@@ -286,7 +286,7 @@
 "moreInformation.cell.infected.title" = "GGD anahtarını paylaşmak";
 "moreInformation.cell.infected.subtitle" = "GGD sizi Korona testinizin sonuçları ile ilgili aradığında buraya gidin";
 
-"moreInformation.info.title" = "Sosyal güvenlik numaranızı hazır bulundurun. Bunu pasaportunuzda veya kimlik kartınızda bulabilirsiniz";
+"moreInformation.info.title" = "Sosyal güvenlik numaranızı hazır bulundurun. Bunu pasaportunuzda veya kimlik kartınızda bulabilirsiniz.";
 
 "moreInformation.complaints.item1" = "burun nezlesi, burun akıntısı, hapşırma, boğaz ağrısı gibi soğuk algınlığı şikayetleri";
 "moreInformation.complaints.item2" = "öksürük";


### PR DESCRIPTION
It was missing in some of the translations only.