### PR TITLE
CI: Update pipelines to Xcode 12.2, iOS 14.2 and iPhone 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: CItest-iphone12
         run: |
           sudo xcode-select -s /Applications/Xcode_12.2.app
-          xcodebuild clean test -version \
+          xcodebuild clean test \
           -project EN.xcodeproj \
           -scheme ENCore \
           -destination "platform=iOS Simulator,OS=latest,name=iPhone 12" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
         run: ./tools/scripts/ci/030_cibuild
       - name: CItest-iphone12
         run: |
-          xcode-select -s /Applications/Xcode_12.2.app
-          sudo xcodebuild clean test -version \
+          sudo xcode-select -s /Applications/Xcode_12.2.app
+          xcodebuild clean test -version \
           -project EN.xcodeproj \
           -scheme ENCore \
           -destination "platform=iOS Simulator,OS=latest,name=iPhone 12" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
         run: ./tools/scripts/ci/030_cibuild
       - name: CItest-iphone12
         run: |
-          xcodebuild clean test \
+          xcode-select -s /Applications/Xcode_12.2.app
+          xcodebuild clean test -version \
           -project EN.xcodeproj \
           -scheme ENCore \
           -destination "platform=iOS Simulator,OS=latest,name=iPhone 12" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: CItest-iphone12
         run: |
           xcode-select -s /Applications/Xcode_12.2.app
-          xcodebuild clean test -version \
+          sudo xcodebuild clean test -version \
           -project EN.xcodeproj \
           -scheme ENCore \
           -destination "platform=iOS Simulator,OS=latest,name=iPhone 12" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
         run: ./tools/scripts/ci/010_ciprep
       - name: CIbuild
         run: ./tools/scripts/ci/030_cibuild
-      - name: CItest-iphone11
+      - name: CItest-iphone12
         run: |
           xcodebuild clean test \
           -project EN.xcodeproj \
           -scheme ENCore \
-          -destination "platform=iOS Simulator,OS=latest,name=iPhone 11" \
+          -destination "platform=iOS Simulator,OS=latest,name=iPhone 12" \
           CODE_SIGN_IDENTITY="" \
           CODE_SIGNING_REQUIRED=NO \
           ONLY_ACTIVE_ARCH=NO

--- a/pipelines/build.yml
+++ b/pipelines/build.yml
@@ -74,7 +74,7 @@ steps:
     xcWorkspacePath: 'EN.xcodeproj'
     scheme: 'EN'
     xcodeVersion: 'specifyPath'
-    xcodeDeveloperDir: '/Applications/Xcode_12.app'
+    xcodeDeveloperDir: '/Applications/Xcode_12.2.app'
     provisioningProfileName: ${{ parameters.provisioningProfileName }}
     signingOption: ${{ parameters.signingOption }}
     packageApp: ${{ parameters.packageApp }}
@@ -89,7 +89,7 @@ steps:
     xcWorkspacePath: EN.xcodeproj
     scheme: ENCore
     xcodeVersion: 'specifyPath'
-    xcodeDeveloperDir: '/Applications/Xcode_12.app'
+    xcodeDeveloperDir: '/Applications/Xcode_12.2.app'
     destinationPlatformOption: iOS
-    destinationSimulators: 'iPhone 11,OS=14.0'
+    destinationSimulators: 'iPhone 12,OS=14.2'
     publishJUnitResults: true


### PR DESCRIPTION
Updates the build.yml Azure pipeline to use:
 - Xcode 12.2
 - iOS 14.2
 - iPhone 12 (as simulation target)

Using Xcode 12.2 improves support for the iPhone 12 series and devices on iOS 14.2.

Also updates the CI.yml Github Actions workflow to target iPhone 12.