### PR TITLE
Github Actions: Revert CI to Xcode 11.7 after automatic update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: macOS-latest
+    runs-on: macos-10.15
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -15,7 +15,9 @@ jobs:
         run: ./tools/scripts/ci/030_cibuild
       - name: CItest-iphone11
         run: |
+          sudo xcode-select -s /Applications/Xcode_11.7.app
           xcodebuild clean test \
+          -version \
           -project EN.xcodeproj \
           -scheme ENCore \
           -destination "platform=iOS Simulator,OS=latest,name=iPhone 11" \


### PR DESCRIPTION
On October 20th, 2020, the default Xcode version of GitHub Actions was switched from 11.7 to 12.0.1, breaking the CI. This PR explicitly sets the Xcode version to revert is back to 11.7 and avoid this from happening in the future.

See also: https://github.com/actions/virtual-environments/issues/1712

The macOS version is also fixed to avoid similar issues in the future (`latest` = `10.15` right now).