### PR TITLE
CI: Use the default Xcode version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
         run: ./tools/scripts/ci/030_cibuild
       - name: CItest-iphone12
         run: |
-          sudo xcode-select -s /Applications/Xcode_12.2.app
           xcodebuild clean test -version \
           -project EN.xcodeproj \
           -scheme ENCore \


### PR DESCRIPTION
Ensures an up-to-date version of Xcode is used.

The currently default version can be found here: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xcode