### PR TITLE
Cache Xcodegen & mockolo

### DIFF
--- a/.github/actions/cache-tools/action.yml
+++ b/.github/actions/cache-tools/action.yml
@@ -1,0 +1,18 @@
+name: cache-tools
+description: "Cache CI tools"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Cache Xcodegen binary
+      uses: actions/cache@v3
+      with:
+        path: |
+          vendor/XcodeGen/.build/apple/Products/Release/xcodegen          
+        key: ${{ runner.os }}-xcodegen-${{ hashFiles('vendor/XcodeGen/Sources') }}      
+    - name: Cache mockolo
+      uses: actions/cache@v3
+      with:
+        path: |
+          vendor/mockolo/.build/release/mockolo         
+        key: ${{ runner.os }}-mockolo-${{ hashFiles('vendor/mockolo/Sources') }}      

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       run: |
         echo "$SERVICE_CREDENTIALS_FILE" > firebase.json
     
+    - name: Cache tools
+      uses: ./.github/actions/cache-tools
+
     - name: Generate TST Project
       env: 
         RELEASE_PROVISIONING_PROFILE: "CoronaMelder_ACC"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+
+    - name: Cache tools
+      uses: ./.github/actions/cache-tools
+
     - name: Generate TST Project
       env: 
         RELEASE_PROVISIONING_PROFILE: "CoronaMelder_ACC"

--- a/tools/scripts/pre-build.sh
+++ b/tools/scripts/pre-build.sh
@@ -78,7 +78,7 @@ fi
 
 cat project.yml
 
-if [ ! -f vendor/XcodeGen/.build/release/xcodegen ] || [ ! -f vendor/mockolo/.build/release/mockolo ];
+if [ ! -f vendor/XcodeGen/.build/apple/Products/Release/xcodegen ] || [ ! -f vendor/mockolo/.build/release/mockolo ];
 then
       make install_ci_deps
 fi


### PR DESCRIPTION
Building Xcodegen and mockolo takes somewhere between 10 and 20 minutes. Previously these binaries were cached. This PR adds that caching again so that the build time is roughly cut in half.